### PR TITLE
Remove path from tcpSocket probes

### DIFF
--- a/helm/prometheus-es-exporter/templates/deployment.yaml
+++ b/helm/prometheus-es-exporter/templates/deployment.yaml
@@ -49,11 +49,9 @@ spec:
             containerPort: {{ .Values.container.port }}
         livenessProbe:
           tcpSocket:
-            path: /
             port: {{ .Values.container.portName }}
         readinessProbe:
           tcpSocket:
-            path: /
             port: {{ .Values.container.portName }}
       {{ if .Values.resources }}
         resources:


### PR DESCRIPTION
The field `path` doesn't exist in TCP probes and it fails on Helm v3 validations